### PR TITLE
switch to nonprivileged Nginx container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ COPY workshop-instructions /build/workshop
 WORKDIR /build
 RUN tar -czf workshop.tar.gz .
 
-FROM nginx:1.19.2-alpine
+FROM nginxinc/nginx-unprivileged:1.19-alpine
 COPY --from=0 /build /usr/share/nginx/html

--- a/deploy/educates/workshop-deploy.yaml
+++ b/deploy/educates/workshop-deploy.yaml
@@ -66,7 +66,7 @@ spec:
         ports:
         - port: 80
           protocol: TCP
-          targetPort: 80
+          targetPort: 8080
         selector:
           deployment: $(workshop_namespace)-docs
     - apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
This is for security best practice and adheres to the security policy defined on ESP clusters.