### PR TITLE
add TLS secret to docs Ingress

### DIFF
--- a/deploy/educates/workshop-deploy.yaml
+++ b/deploy/educates/workshop-deploy.yaml
@@ -89,3 +89,4 @@ spec:
         tls:
         - hosts:
           - $(workshop_namespace)-docs.$(ingress_domain)
+          secretName: eduk8s-wildcard-tls # TODO, determine if this is educates generic or ESP specific


### PR DESCRIPTION
Had to reference a hardcoded secret name of eduk8s-wildcard-tls which I can’t find in the educates documentation. So might be something specific to this ESP cluster, not sure. This allows forward movement regardless though.