### PR TITLE
remove TLS for docs and force instruction tarball to be "http"

### DIFF
--- a/deploy/educates/workshop-deploy.yaml
+++ b/deploy/educates/workshop-deploy.yaml
@@ -11,7 +11,7 @@ spec:
   url: https://github.com/platform-acceleration-lab/cnd-deploy-practices-eduk8s
   content:
     image: quay.io/eduk8s/jdk11-environment
-    files: $(ingress_protocol)://$(workshop_namespace)-docs.$(ingress_domain)/workshop.tar.gz
+    files: http://$(workshop_namespace)-docs.$(ingress_domain)/workshop.tar.gz
   session:
     namespaces:
       budget: large
@@ -86,7 +86,3 @@ spec:
                     number: 80
               path: /
               pathType: Prefix
-        tls:
-        - hosts:
-          - $(workshop_namespace)-docs.$(ingress_domain)
-          secretName: eduk8s-wildcard-tls # TODO, determine if this is educates generic or ESP specific


### PR DESCRIPTION
This should allow the same manifest to work for local and nonlocal.

Since the tarball for the lab instructions is fetched by a shell script on the running workshop session image instance, we don't have to worry about CORS and other web crap. Therefore removing TLS and forcing the tarball to be fetched from http should do the trick and work for all environments.